### PR TITLE
Add secrets for publishing to sonatype

### DIFF
--- a/otterdog/eclipse-edc.jsonnet
+++ b/otterdog/eclipse-edc.jsonnet
@@ -20,6 +20,18 @@ orgs.newOrg('eclipse-edc') {
     },
   },
   secrets+: [
+    orgs.newOrgSecret('ORG_GPG_PASSPHRASE') {
+      value: "pass:bots/technology.edc/gpg/passphrase",
+    },
+    orgs.newOrgSecret('ORG_GPG_PRIVATE_KEY') {
+      value: "pass:bots/technology.edc/gpg/secret-subkeys.asc",
+    },
+    orgs.newOrgSecret('ORG_OSSRH_PASSWORD') {
+      value: "pass:bots/technology.edc/oss.sonatype.org/password",
+    },
+    orgs.newOrgSecret('ORG_OSSRH_USERNAME') {
+      value: "pass:bots/technology.edc/oss.sonatype.org/username",
+    },
     orgs.newOrgSecret('ORGANIZATION_PROJECT') {
       value: "********",
     },
@@ -29,7 +41,7 @@ orgs.newOrg('eclipse-edc') {
     orgs.newOrgSecret('SWAGGERHUB_USER') {
       value: "********",
     },
-  ],
+],
   _repositories+:: [
     orgs.newRepo('.github') {
       allow_merge_commit: false,


### PR DESCRIPTION
As requested in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3658:

This adds organization secrets in order to be able to publish artifacts to sonatype.