### PR TITLE
Remove repositories IDS-Serializer and IDS-CodeGeneration

### DIFF
--- a/otterdog/eclipse-edc.jsonnet
+++ b/otterdog/eclipse-edc.jsonnet
@@ -185,26 +185,6 @@ orgs.newOrg('eclipse-edc') {
         },
       ],
     },
-    orgs.newRepo('IDS-CodeGeneration') {
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      delete_branch_on_merge: false,
-      description: "IDS-CodeGeneration",
-      web_commit_signoff_required: false,
-      workflows+: {
-        default_workflow_permissions: "write",
-      },
-    },
-    orgs.newRepo('IDS-Serializer') {
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      delete_branch_on_merge: false,
-      description: "IDS-Serializer",
-      web_commit_signoff_required: false,
-      workflows+: {
-        default_workflow_permissions: "write",
-      },
-    },
     orgs.newRepo('IdentityHub') {
       allow_rebase_merge: false,
       allow_update_branch: false,


### PR DESCRIPTION
## Description 

These two repositories opened in 2022 got stale due to the decision in favor of another approach.
- https://github.com/eclipse-edc/IDS-Serializer
- https://github.com/eclipse-edc/IDS-CodeGeneration

Reasons: 
- no relation/usage from EDC
- no contributions from EDC community after initial contribution by IDSA
- source code was contributed by IDSA and still is available in their Org if any other project wants to use it
- no active users
- one doesn't even have code available 

## What this PR changes/adds

Remove repositories from otterdog configuration

## Linked Issue(s)
https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4516

