### PR TITLE
chore: remove stale JENKINS TOKEN in all repositories

### DIFF
--- a/otterdog/eclipse-edc.jsonnet
+++ b/otterdog/eclipse-edc.jsonnet
@@ -95,13 +95,7 @@ orgs.newOrg('eclipse-edc') {
       secrets: [
         orgs.newRepoSecret('DISCORD_WEBHOOK_GITHUB') {
           value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_TOKEN') {
-          value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_USER') {
-          value: "********",
-        },
+        }
       ],
       environments: [
         orgs.newEnvironment('Azure-dev'),
@@ -146,13 +140,7 @@ orgs.newOrg('eclipse-edc') {
       secrets: [
         orgs.newRepoSecret('DISCORD_WEBHOOK_GITHUB') {
           value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_TOKEN') {
-          value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_USER') {
-          value: "********",
-        },
+        }
       ],
     },
     orgs.newRepo('GradlePlugins') {
@@ -169,13 +157,7 @@ orgs.newOrg('eclipse-edc') {
       secrets: [
         orgs.newRepoSecret('DISCORD_WEBHOOK_GITHUB') {
           value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_TOKEN') {
-          value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_USER') {
-          value: "********",
-        },
+        }
         orgs.newRepoSecret('GRADLE_PUBLISH_KEY') {
           value: "********",
         },
@@ -199,13 +181,7 @@ orgs.newOrg('eclipse-edc') {
       secrets: [
         orgs.newRepoSecret('DISCORD_WEBHOOK_GITHUB') {
           value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_TOKEN') {
-          value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_USER') {
-          value: "********",
-        },
+        }
       ],
     },
     orgs.newRepo('JenkinsPipelines') {
@@ -317,13 +293,7 @@ orgs.newOrg('eclipse-edc') {
       secrets: [
         orgs.newRepoSecret('DISCORD_WEBHOOK_GITHUB') {
           value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_TOKEN') {
-          value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_USER') {
-          value: "********",
-        },
+        }
       ],
     },
     orgs.newRepo('Release') {
@@ -357,13 +327,7 @@ orgs.newOrg('eclipse-edc') {
       secrets: [
         orgs.newRepoSecret('DISCORD_WEBHOOK_GITHUB') {
           value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_TOKEN') {
-          value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_USER') {
-          value: "********",
-        },
+        }
       ],
     },
     orgs.newRepo('Samples') {
@@ -396,13 +360,7 @@ orgs.newOrg('eclipse-edc') {
       secrets: [
         orgs.newRepoSecret('DISCORD_WEBHOOK_GITHUB') {
           value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_TOKEN') {
-          value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_USER') {
-          value: "********",
-        },
+        }
       ],
     },
     orgs.newRepo('Technology-Azure') {
@@ -419,13 +377,7 @@ orgs.newOrg('eclipse-edc') {
       secrets: [
         orgs.newRepoSecret('DISCORD_WEBHOOK_GITHUB') {
           value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_TOKEN') {
-          value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_USER') {
-          value: "********",
-        },
+        }
         orgs.newRepoSecret('PG_CONNECTION_STRING') {
           value: "********",
         },
@@ -448,13 +400,7 @@ orgs.newOrg('eclipse-edc') {
       secrets: [
         orgs.newRepoSecret('DISCORD_WEBHOOK_GITHUB') {
           value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_TOKEN') {
-          value: "********",
-        },
-        orgs.newRepoSecret('EF_JENKINS_USER') {
-          value: "********",
-        },
+        }
       ],
     },
     orgs.newRepo('Technology-HuaweiCloud') {

--- a/otterdog/eclipse-edc.jsonnet
+++ b/otterdog/eclipse-edc.jsonnet
@@ -157,7 +157,7 @@ orgs.newOrg('eclipse-edc') {
       secrets: [
         orgs.newRepoSecret('DISCORD_WEBHOOK_GITHUB') {
           value: "********",
-        }
+        },
         orgs.newRepoSecret('GRADLE_PUBLISH_KEY') {
           value: "********",
         },

--- a/otterdog/eclipse-edc.jsonnet
+++ b/otterdog/eclipse-edc.jsonnet
@@ -377,7 +377,7 @@ orgs.newOrg('eclipse-edc') {
       secrets: [
         orgs.newRepoSecret('DISCORD_WEBHOOK_GITHUB') {
           value: "********",
-        }
+        },
         orgs.newRepoSecret('PG_CONNECTION_STRING') {
           value: "********",
         },


### PR DESCRIPTION
## What this PR changes/adds

Removes unused "JENKINS" secrets from repositories in eclipse-edc as they are no longer used.
```
orgs.newRepoSecret('EF_JENKINS_TOKEN') {
          value: "********",
        },
        orgs.newRepoSecret('EF_JENKINS_USER') {
          value: "********",
        }
```

## Why it does that

JENKINS related tokens were part of previous release process, which was updated some month ago. We can now get rid of these during chores.

## Further notes

Closes #9 
