### PR TITLE
chore: enable gh-pages for FederatedCatalog

### DIFF
--- a/otterdog/eclipse-edc.jsonnet
+++ b/otterdog/eclipse-edc.jsonnet
@@ -132,6 +132,7 @@ orgs.newOrg('eclipse-edc') {
       description: "FederatedCatalog",
       has_discussions: true,
       has_wiki: false,
+      gh_pages_build_type: "workflow",
       squash_merge_commit_title: "PR_TITLE",
       web_commit_signoff_required: false,
       workflows+: {
@@ -173,9 +174,7 @@ orgs.newOrg('eclipse-edc') {
       description: "IdentityHub",
       has_discussions: true,
       has_wiki: false,
-      gh_pages_build_type: "legacy",
-      gh_pages_source_branch: "gh-pages",
-      gh_pages_source_path: "/",
+      gh_pages_build_type: "workflow",
       squash_merge_commit_title: "PR_TITLE",
       web_commit_signoff_required: false,
       workflows+: {


### PR DESCRIPTION
## What this PR changes/adds

This PR enables GH Pages support for the FederatedCatalog repository.

## Why it does that

enables GH publishing, e.g. for OpenAPI docs

## Further notes

I looked again, and I think we are already publishing to GH Pages from a workflow, so lets try this out first on two of the non-core components (IH and FCC).
If this works, I will create subsequent PRs to change from `legacy` to `workflow` in the other repos as well.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
