### PR TITLE
chore: revert to legacy GH Pages publishing

### DIFF
--- a/otterdog/eclipse-edc.jsonnet
+++ b/otterdog/eclipse-edc.jsonnet
@@ -132,7 +132,9 @@ orgs.newOrg('eclipse-edc') {
       description: "FederatedCatalog",
       has_discussions: true,
       has_wiki: false,
-      gh_pages_build_type: "workflow",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_path: "/",
+      gh_pages_source_branch: "gh-pages",
       squash_merge_commit_title: "PR_TITLE",
       web_commit_signoff_required: false,
       workflows+: {
@@ -174,7 +176,9 @@ orgs.newOrg('eclipse-edc') {
       description: "IdentityHub",
       has_discussions: true,
       has_wiki: false,
-      gh_pages_build_type: "workflow",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "gh-pages",
+      gh_pages_source_path: "/",
       squash_merge_commit_title: "PR_TITLE",
       web_commit_signoff_required: false,
       workflows+: {


### PR DESCRIPTION
## What this PR changes/adds

reverts to the `legacy` method for publishing to GH Pages

## Why it does that

more flexibility in hosting several artifacts, each in multiple versions

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
