### PR TITLE
build: switch gh-pages deployment branch to main

### DIFF
--- a/otterdog/eclipse-edc.jsonnet
+++ b/otterdog/eclipse-edc.jsonnet
@@ -494,7 +494,7 @@ orgs.newOrg('eclipse-edc') {
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [
-            "gh-pages"
+            "main"
           ],
           deployment_branch_policy: "selected",
         },


### PR DESCRIPTION
## What this PR changes/adds

Change the source branch to be used to deployment to "main" for the "docs" repository

## Why it does that

Deployment is done from the main branch, it will solve the error reported in https://github.com/eclipse-edc/docs/issues/176

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes https://github.com/eclipse-edc/docs/issues/176

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
