### PR TITLE
chore: archive docs repo as documentation website has been moved

### DIFF
--- a/otterdog/eclipse-edc.jsonnet
+++ b/otterdog/eclipse-edc.jsonnet
@@ -390,6 +390,7 @@ orgs.newOrg('eclipse-edc') {
       },
     },
     orgs.newRepo('docs') {
+      archived: true,
       allow_rebase_merge: false,
       allow_update_branch: false,
       delete_branch_on_merge: false,


### PR DESCRIPTION
## What this PR changes/adds

archive the docs repo

## Why it does that

not used anymore

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
