### PR TITLE
build: give HuaweiCloud repo workflow write permissions

### DIFF
--- a/otterdog/eclipse-edc.jsonnet
+++ b/otterdog/eclipse-edc.jsonnet
@@ -361,7 +361,7 @@ orgs.newOrg('eclipse-edc') {
         },
       ],
       workflows+: {
-        default_workflow_permissions: "read",
+        default_workflow_permissions: "write",
       },
     },
     orgs.newRepo('Template-Basic') {


### PR DESCRIPTION
## What this PR changes/adds

give HuaweiCloud repo workflow write permissions

## Why it does that

it needs those

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes https://github.com/eclipse-edc/Technology-HuaweiCloud/issues/66

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
