### PR TITLE
chore: update eclipse-edc.jsonnet

### DIFF
--- a/otterdog/eclipse-edc.jsonnet
+++ b/otterdog/eclipse-edc.jsonnet
@@ -435,7 +435,7 @@ orgs.newOrg('eclipse-edc') {
         },
       ],
       workflows+: {
-        default_workflow_permissions: "read",
+        default_workflow_permissions: "write",
       },
       environments: [
         orgs.newEnvironment('github-pages') {


### PR DESCRIPTION
## What this PR changes/adds

Change default-permission for workflows in the Technology-HuaweiCloud repository to `write` to be able to run all actions accordingly.

## Why it does that

Being able to run all workflows.

## Further notes

This change aligns with the other repos.